### PR TITLE
Fix viewType to enable deserialization

### DIFF
--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -368,7 +368,7 @@ paths:
                       vorname: Max
                       nachname: Mustermann
                       typ: PERSON
-                      view_type: PLAKETTE
+                      view_type: Plakette
                       _links:
                         self: 'https://api.europace.de/v2/partnermanagement/partner/AAV43'
                         administrierbare: 'https://api.europace.de/v2/partnermanagement/partner/AAV43/administrierbare'
@@ -810,8 +810,8 @@ components:
     ViewType:
       type: string
       enum:
-        - PLAKETTE
-        - PARTNER
+        - Plakette
+        - Partner
 
     Typ:
       type: string


### PR DESCRIPTION
Für die Deserialisierung müssen viewType und Klassennamen gleich sein. Daher müssen hier die Klassennamen verwendet werden, anstatt upperCase


ich würde das mit dem anderen Update in der 2.0.3 releasen, daher habe ich die version nicht angepasst