### PR TITLE
Further API tweaks

### DIFF
--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -130,6 +130,8 @@ paths:
       description: Liefert die Rechte eines Partners
       security:
         - europace_oauth2: ['partner:rechte:lesen']
+      tags:
+        - Partner
       responses:
         '200':
           description: 'Es werden die Rechte eines Partners zurück gegeben.'
@@ -149,6 +151,8 @@ paths:
       description: Alle Rechte eines Partners aktualisieren
       security:
         - europace_oauth2: ['partner:rechte:schreiben']
+      tags:
+        - Partner
       requestBody:
         content:
           application/json:

--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -789,13 +789,9 @@ components:
           $ref: '#/components/schemas/Link'
         rechte:
           $ref: '#/components/schemas/Link'
-        untergeordnetePartner:
-          $ref: '#/components/schemas/Link'
         partnerkennzeichen:
           $ref: '#/components/schemas/Link'
         administrierbare:
-          $ref: '#/components/schemas/Link'
-        uebernahmeRechtFuer:
           $ref: '#/components/schemas/Link'
       description: 'Additional HAL link relations to other resources'
       required:


### PR DESCRIPTION
Alle anderen endpunkte, inkl. der Unter-Endpunkte, besitzen dieses Tag. 
Es bewirkt, dass am Ende diese beiden Endpunkte in einem separaten Interface landen.

Dieser PR zieht das jetzt gerade

Zusätzlich gibt es noch 2 Endpunkte in der link-sektion, die gelöscht werden.
* `untergeordnetePartner` existiert als Endpunkt gar nicht
* `uebernahmeRechtFuer ` braucht ein target und kann daher nicht automatisch generiert werden
