### PR TITLE
Tweaks

### DIFF
--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -85,6 +85,7 @@ paths:
           content:
             application/json:
               schema:
+                title: Error
                 type: object
                 properties:
                   message:
@@ -406,6 +407,7 @@ paths:
           content:
             application/json:
               schema:
+                title: Uebernehmbare
                 type: object
                 properties:
                   partner:
@@ -463,6 +465,7 @@ paths:
           content:
             application/json:
               schema:
+                title: Target
                 type: object
                 properties:
                   partner:

--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -770,14 +770,22 @@ components:
         partnerKennzeichenDerVertriebsOrganisation:
           type: object
           properties:
+            dslSapGeschaeftspartnerNummerFuerRatenkredit:
+              type: string
             _links:
-              title: _links
-              type: object
-              properties:
-                partner:
-                  $ref: '#/components/schemas/Link'
+              $ref: '#/components/schemas/PartnerkennzeichenLinks'
         _links:
-          $ref: '#/components/schemas/_links'
+          $ref: '#/components/schemas/PartnerkennzeichenLinks'
+
+
+    PartnerkennzeichenLinks:
+      type: object
+      title: _links
+      properties:
+        self:
+          $ref: '#/components/schemas/Link'
+        partner:
+          $ref: '#/components/schemas/Link'
 
     _links:
       title: _links

--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -529,7 +529,7 @@ components:
         kreditsachbearbeiter:
           type: boolean
         _links:
-          $ref: '#/components/schemas/_links'
+          $ref: '#/components/schemas/PartnerLinks'
 
     Partner:
       title: Partner
@@ -651,7 +651,7 @@ components:
               type: boolean
               default: false
         _links:
-          $ref: '#/components/schemas/_links'
+          $ref: '#/components/schemas/PartnerLinks'
 
     Bankverbindung:
       title: bankverbindung
@@ -787,7 +787,7 @@ components:
         partner:
           $ref: '#/components/schemas/Link'
 
-    _links:
+    PartnerLinks:
       title: _links
       type: object
       properties:


### PR DESCRIPTION

* Die Partnerkennzeichen links sind jetzt dieselben wie die von PEX 1.0
* Die Partnerkennzeichen Links wurden als eigenes Objekt rausgezogen
* Inline-Schema namen gegeben, damit die Generierung lesbarer ist
* Links -> PartnerLinks um besser von PartnerkennzeichenLinks zu unterscheiden