### PR TITLE
Rename wlBankVermittlerNummer to dzHypVermittlerNummer

### DIFF
--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -749,7 +749,7 @@ components:
           type: string
         bshBlzVertriebsbank:
           type: string
-        wlBankVermittlerNummer:
+        dzHypVermittlerNummer:
           type: string
         naevVermittlerNummer:
           type: string


### PR DESCRIPTION
Das Partnerkennzeichen ind er PEX 1.0. API heißt schon dzHypVermittlerNummer, das wird hier geradegezogen