### PR TITLE
[PARTNER-214]Markiere alle readOnly Properties im Partner

### DIFF
--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.0.3
 
 info:
   title: partner-api
@@ -503,6 +503,7 @@ components:
           description: Europace PartnerId (readonly)
           minLength: 5
           maxLength: 5
+          readOnly: true
         vorname:
           type: string
           description: "Dieses Feld ist nur für den Typ 'PERSON' gefüllt."
@@ -513,6 +514,7 @@ components:
           type: string
           description: "Dieses Feld ist nur für den Typ 'ORGANISATION' gefüllt."
         typ:
+          readOnly: true
           $ref: '#/components/schemas/Typ'
         email:
           type: string
@@ -522,6 +524,7 @@ components:
         avatar:
           type: string
           format: uri
+          readOnly: true
         gesperrt:
           type: boolean
           default: false
@@ -529,6 +532,7 @@ components:
         kreditsachbearbeiter:
           type: boolean
         _links:
+          readOnly: true
           $ref: '#/components/schemas/PartnerLinks'
 
     Partner:


### PR DESCRIPTION
Closes https://europace.atlassian.net/jira/software/projects/PARTNER/boards/52?issueParent=16546&selectedIssue=PARTNER-214

## Motivation

Wir markieren explizit die readOnly-Properties der Plakette/ des Partners, sodass beim Patch immer klar ist, welche Felder geschrieben werden können.

## Changes

- Upgrade auf OpenAPI 3.0.3
- Neue Read-Only Properties im Partner: partnerId, avatar, _links, typ

## Anmerkungen

- Kotlin Code Generator funktioniert weiterhin
- Postman generiert lässt ReadOnly Felder im Body von Request nun weg - Yeah!!!
- in IntelliJ IDEA gibt es leider eine Warnung: das ein $ref Property und readOnly: true nicht zusammenpassen