### PR TITLE
Lösche `maxLength` für Partner-ID, da wir uns unnötig einschränken

### DIFF
--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -500,7 +500,6 @@ components:
           type: string
           description: Europace PartnerId (readonly)
           minLength: 5
-          maxLength: 5
           readOnly: true
         vorname:
           type: string


### PR DESCRIPTION
Eventuell möchten wir später die Partner-IDs erweitern und wir hätten dann einen Breaking Change. Es gibt aktuell keinen Grund uns hier jetzt schon auf max. 5 Zeichen festzulegen.