### PR TITLE
Markiere `_links` in Rechte als Read-Only Feld

### DIFF
--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -636,6 +636,7 @@ components:
               type: boolean
               default: false
         _links:
+          readOnly: true
           $ref: '#/components/schemas/PartnerLinks'
 
     Bankverbindung:


### PR DESCRIPTION
## Motivation

Markiere `_links` in Rechten als Read-Only Property so dass den Nutzern klar ist, dass man diese nicht patchen kann.