### PR TITLE
Mark kreditsachbearbeiter als readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Bei der serverseitigen Auswertung gelten folgende Regeln:
 - "gesperrtTransitiv" ist nicht von aussen änderbar werden und wird deshalb ignoriert
 - "id" ist nicht änderbar und wird deshalb ignoriert.
 - "typ" ist nicht änderbar und wird deshalb ignoriert.
+- "kreditsachbearbeiter" ist aktuell nur über die Benutzeroberfläche änderbar und wird deshalb ignoriert.
 
 Ein erfolgreicher Aufruf resultiert in einer Response mit dem HTTP Statuscode **200 OK**.
 

--- a/partner-api.yaml
+++ b/partner-api.yaml
@@ -528,6 +528,7 @@ components:
           description: 'true, wenn der Partner oder ein übergeordneter Partner gesperrt ist.'
         kreditsachbearbeiter:
           type: boolean
+          readOnly: true
         _links:
           readOnly: true
           $ref: '#/components/schemas/PartnerLinks'


### PR DESCRIPTION
In der PEX 1 kann man das Feld kreditsachbearbeiter noch nicht setzen.
Daher würde ich das Feld hier vorerst als readOnly setzen und das Problem dann in ein separates Ticket ziehen.

Generell gilt hier: Wir stellen damit nicht weniger Funktionalität zur Verfügung als in PEX 1