### PR TITLE
Doku Partner-API mit Voraussetzungen ergänzt

### DIFF
--- a/docs/Partner_aktualisieren.md
+++ b/docs/Partner_aktualisieren.md
@@ -29,7 +29,7 @@ Für Änderungen an einem Partner benötigt der Aufrufer Einstellungsrechte auf 
 
 ## Beispiel
 Voraussetzungen:
-* Scope `partner:plakette:schreiben`
+* OAuth Token hat den Scope `partner:plakette:schreiben`
 * Aufrufer hat Einstellungsrechte auf den Partner
 
 Beispiel-Request:

--- a/docs/Partner_aktualisieren.md
+++ b/docs/Partner_aktualisieren.md
@@ -28,6 +28,9 @@ Für Änderungen an einem Partner benötigt der Aufrufer Einstellungsrechte auf 
 - webseite
 
 ## Beispiel
+Voraussetzungen:
+* Scope `partner:plakette:schreiben`
+* Aufrufer hat Einstellungsrechte auf den Partner
 
 Beispiel-Request:
 ```

--- a/docs/Partner_anlegen.md
+++ b/docs/Partner_anlegen.md
@@ -5,7 +5,11 @@ Das Anlegen eines neuen Partners erfolgt immer unterhalb eines bestehenden Partn
 https://api.europace.de/v2/partner/{PartnerId}/untergeordnete
 ```
 
-Für das Anlegen neuer Partner benötigt der Aufrufer das Recht "Darf Organisationseinheiten anlegen" sowie Einstellungsrechte auf denjenigen Partner, unterhalb dessen der neue Partner angelegt werden soll. 
+Voraussetzungen:
+* Scope ` partner:plakette:anlegen `
+* Aufrufer ist ein Partner vom Typ Person
+* Aufrufer hat das Recht "Darf Organisationseinheiten anlegen" 
+* Aufrufer hat Einstellungsrechte auf den Partner, unter dem der neue Partner angelegt werden soll
 
 Beispiel-Request:
 ``` curl 

--- a/docs/Partner_anlegen.md
+++ b/docs/Partner_anlegen.md
@@ -6,7 +6,7 @@ https://api.europace.de/v2/partner/{PartnerId}/untergeordnete
 ```
 
 Voraussetzungen:
-* Scope ` partner:plakette:anlegen `
+* OAuth Token hat den Scope `partner:plakette:anlegen `
 * Aufrufer ist ein Partner vom Typ Person
 * Aufrufer hat das Recht "Darf Organisationseinheiten anlegen" 
 * Aufrufer hat Einstellungsrechte auf den Partner, unter dem der neue Partner angelegt werden soll
@@ -120,4 +120,3 @@ Content-Type: application/json;charset=utf-8
 > - email
 > 
 > Eine Angebotsannahme ist andernfalls nicht möglich.
-

--- a/docs/Partner_auslesen.md
+++ b/docs/Partner_auslesen.md
@@ -1,5 +1,9 @@
 # Beispiel: Stammdaten eines Benutzers auslesen
 
+Voraussetzungen:
+* Scope ` partner:plakette:lesen `
+* Für den Zugriff auf einen Partner benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
+
 Beispiel-Request: 
 ``` curl
 curl --location --request GET 'https://api.europace.de/v2/partner/ABC12/' \
@@ -7,8 +11,6 @@ curl --location --request GET 'https://api.europace.de/v2/partner/ABC12/' \
 --header 'X-TraceId: {{meineTraceId}}' \
 --header 'Authorization: Bearer {{access_token}}'
 ```
-
-Für den Zugriff auf einen Partner benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 Die aus den Einstellungen bekannte Vererbung von Werten bestimmter Attribute entlang der Hierarchie wird in der API nicht reflektiert. **Geerbte Werte werden also nicht ausgeliefert.**
 

--- a/docs/Partner_auslesen.md
+++ b/docs/Partner_auslesen.md
@@ -1,7 +1,7 @@
 # Beispiel: Stammdaten eines Benutzers auslesen
 
 Voraussetzungen:
-* Scope ` partner:plakette:lesen `
+* OAuth Token hat den Scope `partner:plakette:lesen `
 * Für den Zugriff auf einen Partner benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 Beispiel-Request: 

--- a/docs/Partnerkennzeichen_auslesen.md
+++ b/docs/Partnerkennzeichen_auslesen.md
@@ -2,6 +2,10 @@
 
 Die Partnerkennzeichen identifizieren einen Vertrieb bei einem Produktanbieter. 
 
+Vorausetzungen:
+* Scope ` partner:plakette:lesen `
+* für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
+
 Beispiel-Request:
 ```
 GET /v2/partner/ABC12/partnerkennzeichen HTTP/1.1
@@ -11,8 +15,6 @@ Authorization: Bearer eyJraWQiOiJ...
 X-TraceId: request-2020-08-28-07-59
 Accept: application/json
 ```
-
-Für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 Die aus den Einstellungen bekannte Vererbung von Werten bestimmter Attribute entlang der Hierarchie wird in der API nicht reflektiert. **Geerbte Werte werden also nicht ausgeliefert.**
 

--- a/docs/Partnerkennzeichen_auslesen.md
+++ b/docs/Partnerkennzeichen_auslesen.md
@@ -3,7 +3,7 @@
 Die Partnerkennzeichen identifizieren einen Vertrieb bei einem Produktanbieter. 
 
 Vorausetzungen:
-* Scope ` partner:plakette:lesen `
+* OAuth Token hat den Scope `partner:plakette:lesen `
 * für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 Beispiel-Request:

--- a/docs/Rechte_auslesen.md
+++ b/docs/Rechte_auslesen.md
@@ -1,6 +1,6 @@
 # Beispiel: Rechte eines Partners
 Voraussetzungen für alle Anwendungsfälle und Beispiele:
-* Scope `partner:plakette:lesen`
+* OAuth Token hat den Scope `partner:plakette:lesen`
 * für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 ## Personen-Rechte auslesen
@@ -123,5 +123,4 @@ Content-Type: application/json;charset=utf-8
   ]
 }
 ```
-
 

--- a/docs/Rechte_auslesen.md
+++ b/docs/Rechte_auslesen.md
@@ -1,6 +1,10 @@
 # Beispiel: Rechte eines Partners
+Voraussetzungen für alle Anwendungsfälle und Beispiele:
+* Scope `partner:plakette:lesen`
+* für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 ## Personen-Rechte auslesen
+
 Beispiel-Request:
 ``` http
 GET /v2/partner/ABC12/rechte HTTP/1.1

--- a/docs/Zugang.md
+++ b/docs/Zugang.md
@@ -12,6 +12,10 @@ https://api.europace.de/v2/partner/{PartnerId}/zugang
 
 Dem Benutzer mit der PartnerId:ABC12 wird ein Zugang mit dem Benutzernamen "max.musterman@exmaple.org" eingerichtet und eine Aktivierungs-E-Mail (sendEmail=true) an seinen Benutzernamen gesendet, die ihn zur Festlegung seines Passwortes auffordert.
 
+Voraussetzung:
+* Scope `partner:plakette:schreiben`
+* für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
+
 Beispiel-Request: 
 ```
 POST /v2/partner/ABC12/zugang?sendEmail=true HTTP/1.1
@@ -34,6 +38,9 @@ Der Body des Responses bleibt leer.
 
 
 ## Zugang auslesen
+Voraussetzungen:
+* Scope `partner:plakette:lesen`
+* für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 Beispiel-Request:
 ```
@@ -44,8 +51,6 @@ Authorization: Bearer eyJraWQiOiJWRDZZTk...
 X-TraceId: ff-request-2020-08-28-07-59
 Content-Type: application/json
 ```
-
-In folgenden Beispiel loggt der .
 
 Beispiel-Response, für einen Partner, der sich am Europace-Identity-Provider authentifizert (Europace-Passwort):
 ```

--- a/docs/Zugang.md
+++ b/docs/Zugang.md
@@ -39,7 +39,7 @@ Der Body des Responses bleibt leer.
 
 ## Zugang auslesen
 Voraussetzungen:
-* Scope `partner:plakette:lesen`
+* OAuth Token hat den Scope `partner:plakette:lesen`
 * für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 Beispiel-Request:

--- a/docs/Zugang.md
+++ b/docs/Zugang.md
@@ -13,7 +13,7 @@ https://api.europace.de/v2/partner/{PartnerId}/zugang
 Dem Benutzer mit der PartnerId:ABC12 wird ein Zugang mit dem Benutzernamen "max.musterman@exmaple.org" eingerichtet und eine Aktivierungs-E-Mail (sendEmail=true) an seinen Benutzernamen gesendet, die ihn zur Festlegung seines Passwortes auffordert.
 
 Voraussetzung:
-* Scope `partner:plakette:schreiben`
+* OAuth Token hat den Scope `partner:plakette:schreiben`
 * für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 Beispiel-Request: 


### PR DESCRIPTION
- Jeder Anwendungsfall enthält jetzt neben dem Bespiel-Request auch einen Abschnitt "Voraussetzungen"
- bisheriger Fließtext wurde hier eingearbeitet