### PR TITLE
identityProviderBenutzername ergänzt

### DIFF
--- a/docs/Zugang.md
+++ b/docs/Zugang.md
@@ -1,23 +1,23 @@
 # Beispiel: Zugang anlegen und auslesen
 
-Ein neu angelegter Partner braucht einen "Zugang" um sich an der Plattform mit seinem Benutzernamen anmelden zu können. Der Zugang kann entweder über die Einstellungen (Partnermanagement) oder durch einen API-Request erstellt werden.
-
-HINWEIS: das Anlegen eines Zugangs per POST Request macht in der aktuellen Ausbaustufe nur Sinn, wenn der Partner einen externen Identity Provider (z.B. Active Directory) nutzt. Denn ein Partner, dessen Zugang per POST Request angelegt wird, hat bei Europace kein eigenes Passwort (sein Passwort ist im externen Identity Provider hinterlegt).
-
-Das Url-Template für das Anlegen eines Zugangs für den Partner mit {PartnerId} lautet:
-https://api.europace.de/v2/partner/{PartnerId}/zugang
+Ein neu angelegter Partner braucht einen "Zugang" um sich an Europace mit seinem Benutzernamen anmelden zu können. Der Zugang kann entweder über die Einstellungen (Partnermanagement) oder durch die Partner-API erstellt werden.
 
 ## Zugang anlegen
 
-Dem Benutzer mit der PartnerId:ABC12 wird ein Zugang mit dem Benutzernamen "max.musterman@exmaple.org" eingerichtet und eine Aktivierungs-E-Mail (sendEmail=true) an seinen Benutzernamen gesendet, die ihn zur Festlegung seines Passwortes auffordert.
-
-Hinweis:
-Als Antwort-Adresse in der Aktivierungs-E-Mail wird die E-Mail oder der Benutzername des Subject im OAuth-Token verwendet.
-Ist keine E-Mail oder Benutzername vorhanden geht die Antwort an noreply@europace2.de.
-
-Voraussetzung:
+Voraussetzung für alle Anwendungsfälle:
 * OAuth Token hat den Scope `partner:plakette:schreiben`
 * für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
+
+### Anwendungsfall 1: Europace-Benutzer anlegen
+Dem Benutzer mit der PartnerId:ABC12 wird ein Zugang mit dem Benutzernamen "max.musterman@exmaple.org" eingerichtet und eine Aktivierungs-E-Mail (`sendEmail=true`) an seinen Benutzernamen gesendet. In der Aktivierungs-E-Mail wird die Benutzer:in zur Festlegung ihres Passwortes auffordert.
+
+>Hinweis: \
+>Als Antwort-Adresse in der Aktivierungs-E-Mail wird die E-Mail oder der Benutzername des Subject >im OAuth-Token verwendet, die den Zugang angelegt hat.
+>Ist keine E-Mail oder Benutzername vorhanden geht die Antwort an noreply@europace2.de.
+
+Voraussetzung für Anwendungsfall 1:
+* der Benutzername ist Europace-weit eindeutig
+* der Benutzername ist eine E-Mail-Adresse
 
 Beispiel-Request: 
 ```
@@ -29,18 +29,123 @@ X-TraceId: ff-request-2020-08-28-07-59
 Content-Type: application/json
 
 {
-    "benutzername" : "max.musterman@exmaple.org"
+    "benutzername" : "max.musterman@example.org"
 }
 ```
 
 Beispiel-Response:
 ```
 HTTP-Code: 201 created
+{
+    "partnerId": "ABC12",
+    "status": "ZUGANG_UNBESTAETIGT",
+    "benutzername": "max.musterman@example.org",
+}
 ```
-Der Body des Responses bleibt leer.
 
+### Anwendungsfall 2: Benutzer für eigenen Identity Provider anlegen
+Dieser Anwendungsfall ist vor allem bei Bankpartnern üblich, bei dem alle Mitarbeiter eine firmeneigene E-Mail mit eigener Domäne haben und die Mitarbeiter ausschließlich innerhalb dieser Organisation arbeiten. Das trifft auch auf Vertriebe zu, die den Vertrieb mit ausschließlich eigenen Angestellten meist im Direktvertrieb leisten.
+
+In diesem Anwendungsfall wird der Identity Provider des Partners konfiguriert und der Benutzername als Benutzers-Identifikation bei Europace und dem Identity Provider des Partners verwendet.
+
+Da es sich um einen bestehenden Benutzer im Identity Provider des Partners handelt, darf keine Aktivierungs-E-Mail versendet werden (`sendEmail=false`).
+
+Voraussetzung für Anwendungsfall 2:
+* der Benutzername ist Europace-weit eindeutig
+* der Benutzername ist eine E-Mail-Adresse
+
+Beispiel-Request: 
+```
+POST /v2/partner/ABC12/zugang?sendEmail=false HTTP/1.1
+Host: api.europace.de
+Accept: application/json
+Authorization: Bearer eyJraWQiOiJWRDZZTk...
+X-TraceId: ff-request-2020-08-28-07-59
+Content-Type: application/json
+
+{
+    "benutzername" : "max.musterman@deineOrganisation.de"
+}
+```
+
+Beispiel-Response:
+```
+HTTP-Code: 201 created
+{
+    "partnerId": "ABC12",
+    "status": "ZUGANG_REGISTRIERT",
+    "benutzername": "max.musterman@deineOrganisation.de",
+    "identityProviderConfigURL": "https://idp.deineOrganisation.de/auth/realms/.well-known/openid-configuration"
+}
+```
+
+### Anwendungsfall 3: Benutzername ist Europace-weit nicht eindeutig oder keine E-Mail-Adresse 
+Es soll ein Benutzer für den eigenen Identity Provider angelegt werden, aber der Benutzername ist  Europace-weit nicht eindeutig oder keine E-Mail-Adresse. In diesem Fall wird das Feld `benutzername` gar nicht verwendet, sondern ausschließlich das Feld `identityProviderBenutzername`. Die Identifikation des Benutzers auf der Loginmaske kann nur noch über die Partner-Id erfolgen. Die Partner-Id kann in manchen Anwendungsfällen mit dem Parameter `login_hint` an die Loginseite übergeben werden, um die Benutzererfahrung zu verbessern.
+
+Da es sich um einen bestehenden Benutzer im Identity Provider des Partners und der identityProviderBenutzername nur dort verwendet wird, wird keine Aktivierungs-E-Mail versendet, unabhängig vom Parameter `sendEmail`.
+
+Voraussetzung für Anwendungsfall 3:
+* keine weiteren
+
+Beispiel-Request: 
+```
+POST /v2/partner/ABC12/zugang HTTP/1.1
+Host: api.europace.de
+Accept: application/json
+Authorization: Bearer eyJraWQiOiJWRDZZTk...
+X-TraceId: ff-request-2020-08-28-07-59
+Content-Type: application/json
+
+{
+    "identityProviderBenutzername" : "max.mustermann01"
+}
+```
+
+Beispiel-Response:
+```
+HTTP-Code: 201 created
+{
+    "partnerId": "ABC12",
+    "status": "ZUGANG_REGISTRIERT",
+    "identityProviderBenutzername": "max.mustermann01",
+    "identityProviderConfigURL": "https://idp.deineOrganisation.de/auth/realms/.well-known/openid-configuration"
+}
+```
+
+## Benutzernamen ändern
+Die Benutzernamen von externen Identity Providern können über die Partner-API geändert werden.
+
+Einschränkung:
+* das Feld `benutzername` kann nicht angepasst werden
+
+Beispiel-Request: 
+```
+PATCH /v2/partner/ABC12/zugang HTTP/1.1
+Host: api.europace.de
+Accept: application/json
+Authorization: Bearer eyJraWQiOiJWRDZZTk...
+X-TraceId: ff-request-2020-08-28-07-59
+Content-Type: application/json
+
+{
+    "identityProviderBenutzername" : "max.muster"
+}
+```
+
+Beispiel-Response:
+```
+HTTP-Code: 200 okay
+{
+    "partnerId": "ABC12",
+    "status": "ZUGANG_REGISTRIERT",
+    "identityProviderBenutzername": "max.muster",
+    "identityProviderConfigURL": "https://idp.deineOrganisation.de/auth/realms/.well-known/openid-configuration"
+}
+```
 
 ## Zugang auslesen
+Um den aktuellen Zustand zu ermitteln, läßt sich dieser auslesen.
+
 Voraussetzungen:
 * OAuth Token hat den Scope `partner:plakette:lesen`
 * für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
@@ -63,7 +168,7 @@ Content-Type: application/json;charset=utf-8
 {
     "partnerId": "ABC12",
     "status": "ZUGANG_REGISTRIERT",
-    "benutzername": "max.mustermann@email.de"
+    "benutzername": "max.musterman@example.org",
 }
 ```
 
@@ -73,9 +178,9 @@ Beispiel-Response, für einen Partner, der sich mit einem eigenen Identity-Provi
 Content-Type: application/json;charset=utf-8
 
 {
-    "partnerId": "SCR06",
-    "benutzername": "max.mustermann@email.de",
+    "partnerId": "ABC12",
     "status": "ZUGANG_REGISTRIERT",
-    "identityProviderConfigURL": "https://auth.meineDomain.de/adfs/.well-known/openid-configuration"
+    "identityProviderBenutzername": "max.muster",
+    "identityProviderConfigURL": "https://auth.deineOrganisation.de/adfs/.well-known/openid-configuration"
 }
 ```

--- a/docs/Zugang.md
+++ b/docs/Zugang.md
@@ -1,19 +1,19 @@
 # Beispiel: Zugang anlegen und auslesen
 
-Ein neu angelegter Partner braucht einen "Zugang" um sich an Europace mit seinem Benutzernamen anmelden zu können. Der Zugang kann entweder über die Einstellungen (Partnermanagement) oder durch die Partner-API erstellt werden.
+Eine neu angelegte Partner:in braucht einen "Zugang" um sich an Europace mit ihrem Benutzernamen anmelden zu können. Der Zugang kann entweder über die Einstellungen (Partnermanagement) oder durch die Partner-API erstellt werden.
 
 ## Zugang anlegen
 
 Voraussetzung für alle Anwendungsfälle:
 * OAuth Token hat den Scope `partner:plakette:schreiben`
-* für den Zugriff auf einen Partner und dessen Partnerkennzeichen benötigt der Aufrufer grundsätzlich die Berechtigung, diesen zu sehen. Dieses Recht besteht, wenn der abgerufenene Partner in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
+* für den Zugriff auf die Partner:in und ihre Partnerkennzeichen benötigt die Aufrufer:in grundsätzlich die Berechtigung, diese zu sehen. Dieses Recht besteht, wenn die abgerufenene Partner:in in der Hierachie unter der authentifizierten Plakette liegt oder das Administrationsrecht an die authentifizierte Plakette vergeben ist.
 
 ### Anwendungsfall 1: Europace-Benutzer anlegen
-Dem Benutzer mit der PartnerId:ABC12 wird ein Zugang mit dem Benutzernamen "max.musterman@exmaple.org" eingerichtet und eine Aktivierungs-E-Mail (`sendEmail=true`) an seinen Benutzernamen gesendet. In der Aktivierungs-E-Mail wird die Benutzer:in zur Festlegung ihres Passwortes auffordert.
+Der Benutzer:in mit der PartnerId:ABC12 wird ein Zugang mit dem Benutzernamen "max.musterman@exmaple.org" eingerichtet und eine Aktivierungs-E-Mail (`sendEmail=true`) an ihren Benutzernamen gesendet. In der Aktivierungs-E-Mail wird die Benutzer:in zur Festlegung ihres Passwortes auffordert.
 
 >Hinweis: \
->Als Antwort-Adresse in der Aktivierungs-E-Mail wird die E-Mail oder der Benutzername des Subject >im OAuth-Token verwendet, die den Zugang angelegt hat.
->Ist keine E-Mail oder Benutzername vorhanden geht die Antwort an noreply@europace2.de.
+>Als Antwort-Adresse in der Aktivierungs-E-Mail wird die E-Mail oder der Benutzername des Subject im OAuth-Token verwendet, die den Zugang angelegt hat.
+>Ist keine E-Mail-Adresse oder Benutzername vorhanden geht die Antwort an noreply@europace2.de.
 
 Voraussetzung für Anwendungsfall 1:
 * der Benutzername ist Europace-weit eindeutig
@@ -29,7 +29,7 @@ X-TraceId: ff-request-2020-08-28-07-59
 Content-Type: application/json
 
 {
-    "benutzername" : "max.musterman@example.org"
+    "benutzername" : "maxi.musterman@example.org"
 }
 ```
 
@@ -39,16 +39,16 @@ HTTP-Code: 201 created
 {
     "partnerId": "ABC12",
     "status": "ZUGANG_UNBESTAETIGT",
-    "benutzername": "max.musterman@example.org",
+    "benutzername": "maxi.musterman@example.org",
 }
 ```
 
 ### Anwendungsfall 2: Benutzer für eigenen Identity Provider anlegen
-Dieser Anwendungsfall ist vor allem bei Bankpartnern üblich, bei dem alle Mitarbeiter eine firmeneigene E-Mail mit eigener Domäne haben und die Mitarbeiter ausschließlich innerhalb dieser Organisation arbeiten. Das trifft auch auf Vertriebe zu, die den Vertrieb mit ausschließlich eigenen Angestellten meist im Direktvertrieb leisten.
+Dieser Anwendungsfall ist vor allem bei Bankpartnern oder Direktvertrieben üblich, bei denen alle Mitarbeiter eine firmeneigene E-Mail mit eigener Domäne haben und die Mitarbeiter ausschließlich innerhalb dieser Organisation arbeiten.
 
 In diesem Anwendungsfall wird der Identity Provider des Partners konfiguriert und der Benutzername als Benutzers-Identifikation bei Europace und dem Identity Provider des Partners verwendet.
 
-Da es sich um einen bestehenden Benutzer im Identity Provider des Partners handelt, darf keine Aktivierungs-E-Mail versendet werden (`sendEmail=false`).
+Da es sich um einen bestehende Benutzer:in im Identity Provider des Partners handelt, darf keine Aktivierungs-E-Mail versendet werden (`sendEmail=false`).
 
 Voraussetzung für Anwendungsfall 2:
 * der Benutzername ist Europace-weit eindeutig
@@ -64,7 +64,7 @@ X-TraceId: ff-request-2020-08-28-07-59
 Content-Type: application/json
 
 {
-    "benutzername" : "max.musterman@deineOrganisation.de"
+    "benutzername" : "maxi.musterman@deineOrganisation.de"
 }
 ```
 
@@ -74,15 +74,15 @@ HTTP-Code: 201 created
 {
     "partnerId": "ABC12",
     "status": "ZUGANG_REGISTRIERT",
-    "benutzername": "max.musterman@deineOrganisation.de",
+    "benutzername": "maxi.musterman@deineOrganisation.de",
     "identityProviderConfigURL": "https://idp.deineOrganisation.de/auth/realms/.well-known/openid-configuration"
 }
 ```
 
 ### Anwendungsfall 3: Benutzername ist Europace-weit nicht eindeutig oder keine E-Mail-Adresse 
-Es soll ein Benutzer für den eigenen Identity Provider angelegt werden, aber der Benutzername ist  Europace-weit nicht eindeutig oder keine E-Mail-Adresse. In diesem Fall wird das Feld `benutzername` gar nicht verwendet, sondern ausschließlich das Feld `identityProviderBenutzername`. Die Identifikation des Benutzers auf der Loginmaske kann nur noch über die Partner-Id erfolgen. Die Partner-Id kann in manchen Anwendungsfällen mit dem Parameter `login_hint` an die Loginseite übergeben werden, um die Benutzererfahrung zu verbessern.
+Es soll eine Benutzer:in für den eigenen Identity Provider angelegt werden, aber der Benutzername ist Europace-weit nicht eindeutig oder keine E-Mail-Adresse. In diesem Fall wird das Feld `benutzername` gar nicht verwendet, sondern ausschließlich das Feld `identityProviderBenutzername`. Die Identifikation der Benutzer:in auf der Anmelde-Maske kann nur noch über die Partner-Id erfolgen. Die Partner-Id kann in manchen Anwendungsfällen mit dem Parameter `login_hint` an die Anmelde-Maske übergeben werden, um die Benutzererfahrung zu verbessern.
 
-Da es sich um einen bestehenden Benutzer im Identity Provider des Partners und der identityProviderBenutzername nur dort verwendet wird, wird keine Aktivierungs-E-Mail versendet, unabhängig vom Parameter `sendEmail`.
+Da es sich um eine bestehende Benutzer:in im Identity Provider des Partners handelt und der identityProviderBenutzername nur dort verwendet wird, wird keine Aktivierungs-E-Mail versendet, unabhängig vom Parameter `sendEmail`.
 
 Voraussetzung für Anwendungsfall 3:
 * keine weiteren
@@ -97,7 +97,7 @@ X-TraceId: ff-request-2020-08-28-07-59
 Content-Type: application/json
 
 {
-    "identityProviderBenutzername" : "max.mustermann01"
+    "identityProviderBenutzername" : "maxi.mustermann01"
 }
 ```
 
@@ -107,12 +107,12 @@ HTTP-Code: 201 created
 {
     "partnerId": "ABC12",
     "status": "ZUGANG_REGISTRIERT",
-    "identityProviderBenutzername": "max.mustermann01",
+    "identityProviderBenutzername": "maxi.mustermann01",
     "identityProviderConfigURL": "https://idp.deineOrganisation.de/auth/realms/.well-known/openid-configuration"
 }
 ```
 
-## Benutzernamen ändern
+## Benutzernamen für Identity Provider ändern
 Die Benutzernamen von externen Identity Providern können über die Partner-API geändert werden.
 
 Einschränkung:
@@ -128,7 +128,7 @@ X-TraceId: ff-request-2020-08-28-07-59
 Content-Type: application/json
 
 {
-    "identityProviderBenutzername" : "max.muster"
+    "identityProviderBenutzername" : "maxi.muster"
 }
 ```
 
@@ -138,7 +138,7 @@ HTTP-Code: 200 okay
 {
     "partnerId": "ABC12",
     "status": "ZUGANG_REGISTRIERT",
-    "identityProviderBenutzername": "max.muster",
+    "identityProviderBenutzername": "maxi.muster",
     "identityProviderConfigURL": "https://idp.deineOrganisation.de/auth/realms/.well-known/openid-configuration"
 }
 ```
@@ -168,7 +168,7 @@ Content-Type: application/json;charset=utf-8
 {
     "partnerId": "ABC12",
     "status": "ZUGANG_REGISTRIERT",
-    "benutzername": "max.musterman@example.org",
+    "benutzername": "maxi.musterman@example.org",
 }
 ```
 
@@ -180,7 +180,7 @@ Content-Type: application/json;charset=utf-8
 {
     "partnerId": "ABC12",
     "status": "ZUGANG_REGISTRIERT",
-    "identityProviderBenutzername": "max.muster",
+    "identityProviderBenutzername": "maxi.muster",
     "identityProviderConfigURL": "https://auth.deineOrganisation.de/adfs/.well-known/openid-configuration"
 }
 ```

--- a/partner-openapi.yaml
+++ b/partner-openapi.yaml
@@ -546,6 +546,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Zugang'
+        '401':
+          description: Unauthorized
         '403':
           description: Forbidden - kein Zugriff
         '404':
@@ -568,7 +570,7 @@ paths:
             default: false
           required: false
           example: true
-          description: 'Es wird eine E-Mail an den Benutzernamen gesendet, der ihn zur Vergabe eines Passwortes anleitet.'
+          description: 'Wenn der Benutzername gesetzt ist, wird eine E-Mail an den Benutzernamen gesendet, der ihn zur Vergabe eines Passwortes anleitet.'
       responses:
         '201':
           description: |-
@@ -581,6 +583,8 @@ paths:
                 $ref: '#/components/schemas/Zugang'
         '400':
           description: Bad Request - Anfrage ungültig/konnte nicht verstanden werden
+        '401':
+          description: Unauthorized
         '406':
           description: Not Acceptable
           content:
@@ -609,6 +613,8 @@ paths:
                     statusMessage: Ein Zugang kann nur an einer Person nicht einer Organisation angelegt werden.
                     timestamp: '2021-01-20T10:03:29.02'
                     traceId: XABC-122...
+        '409':
+          description: Conflict - es existiert bereits ein benutzername im Zugang
       requestBody:
         required: true
         content:
@@ -622,10 +628,44 @@ paths:
                   example: max.mustermann@email.de
                   format: email
                   description: 'Eine in Europace eindeutige Emailadresse, die als Identifikation des Benutzers verwendet wird. '
-              required:
-                - benutzername
+                identityProviderBenutzername:
+                  type: string
+                  description: Benutzername für den IdentityProvider. Die Eindeutigkeit ist nicht relevant. Ist das Feld <null> wird der Benutzername für den Identity Provider verwendet.
         description: ''
       description: Erzeugt einen Zugang für eine Person.
+    patch:
+      summary: ''
+      operationId: patchZugang
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Zugang'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - kein Zugriff
+        '404':
+          description: Not Found - Partner nicht gefunden
+      description: Ändert Benutzernamen und/oder IdP-Benutzernamen.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              title: PatchZugang
+              properties:
+                identityProviderBenutzername:
+                  type: string
+                  description: Benutzername für den IdentityProvider. Die Eindeutigkeit ist nicht relevant. Ist das Feld <null> wird der Benutzername für den Identity Provider verwendet.
+                  example: max.mustermann
+            examples:
+              IdP-Benutzernamen ändern:
+                identityProviderBenutzername: max.mustermann01
+        description: 'Es brauchen nur die Attribute angegeben werden, die sich verändern sollen.'
 components:
   securitySchemes:
     europace_oauth2:
@@ -943,6 +983,9 @@ components:
             ZUGANG_REGISTRIERT = Benutzername ist vergeben und verifiziert
             ZUGANG_REGISTRIERT_KEIN_ZUGANG = Benutzername ist vergeben und verifiziert aber gesperrt
             BENUTZERNAME_AENDERUNG_UNBESTAETIGT = Benutzername wurde geändert und noch nicht verifiziert
+        identityProviderBenutzername:
+          type: string
+          description: Benutzername am Identity Provider. Ist er <null> wird `benutzername` verwendet.
         identityProviderConfigURL:
           type: string
           description: 'Gültiger Identity Provider, der bei einer Authentifizierung durch den Benutzer verwendet wird.'


### PR DESCRIPTION
- Anwendungsfälle für idpBenutzername ergänzt
- OAS erweitert
- genderneutrale Sprache verwendet