### PR TITLE
Fix tag Partner in partner-api.yml

### DIFF
--- a/partner-openapi.yaml
+++ b/partner-openapi.yaml
@@ -893,7 +893,7 @@ paths:
     post:
       summary: create user access
       tags:
-        - partner
+        - Partner
       operationId: createZugang
       security:
         - europace_oauth2:


### PR DESCRIPTION
## Motivation

Fix tag in `partner-openapi.yml` as requested in https://github.com/europace/partner-edge-server/pull/295
