### PR TITLE
#KITT-2413 add v3.0 to support qualifikation in kontaktdaten  and partner api. v2.0 is still supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ Example response Organisation:
         "ort": "Berlin"
     },
     "qualifikation": {
-    "paragraph34d": {
-      "registrierungsnummer": "D-W-133-8B1Z-28"
-    },
-    "paragraph34i": {
-      "registrierungsnummer": "D-W-7943497238942",
-      "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
+        "paragraph34d": {
+          "registrierungsnummer": "D-W-133-8B1Z-28"
+        },
+        "paragraph34i": {
+          "registrierungsnummer": "D-W-7943497238942",
+          "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
+        }
     }
-  }
 }
 ```
 

--- a/README_2_0.md
+++ b/README_2_0.md
@@ -1,10 +1,10 @@
-# Partner API
+# Partner API v2.0
+
+**Attention: You are not viewing the latest version. You can find the latest version [here](https://docs.api.europace.de/common/partner-settings/partner-api/).**
 
 The Partner API enables automation of Europace's user management. The partner management (settings) is used by Europace partners to map their own user and rights structure. 
 
 Partners can be users as well as organizations like companies, departments or teams. Each partner is created in the hierarchy tree as [Plakette](https://docs.api.europace.de/common/glossary/) of type [Person](https://docs.api.europace.de/common/glossary/) or [Organisation](https://docs.api.europace.de/common/glossary/).
-
-Note: Currently version 2.0 as well as version 3.0 are supported. The documentation for version 2.0 can be found [here](README_2_0.md).
 
 ---- 
 ![advisor](https://img.shields.io/badge/-advisor-lightblue)
@@ -13,13 +13,13 @@ Note: Currently version 2.0 as well as version 3.0 are supported. The documentat
 ![consumerLoan](https://img.shields.io/badge/-consumerLoan-lightblue)
 
 [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://docs.api.europace.de/baufinanzierung/authentifizierung/)
-[![GitHub release](https://img.shields.io/github/v/release/europace/partner-api)](https://github.com/europace/partner-api/releases)
+[![GitHub release](https://img.shields.io/github/v/release/europace/partner-api)](https://github.com/europace/partner-api/releases/tag/v2.0)
 
 [![Pattern](https://img.shields.io/badge/Pattern-Tolerant%20Reader-yellowgreen)](https://martinfowler.com/bliki/TolerantReader.html)
 
 ## Dokumentation
 [![YAML](https://img.shields.io/badge/OAS-HTML_Doc-lightblue)](https://europace.github.io/partner-api)
-[![YAML](https://img.shields.io/badge/OAS-YAML-lightgrey)](https://github.com/europace/partner-api/blob/master/partner-openapi.yaml)
+[![YAML](https://img.shields.io/badge/OAS-YAML-lightgrey)](https://github.com/europace/partner-api/blob/master/partner-openapi_2_0.yaml)
 
 For translation of our german domain-specific-language the [glossary](https://docs.api.europace.de/common/glossary/) will support you.
 
@@ -70,7 +70,7 @@ and/or
 
 Example request: 
 ``` curl
-curl --location --request GET 'https://api.europace.de/v3/partner/ABC12/kontaktdaten' \
+curl --location --request GET 'https://api.europace.de/v2/partner/ABC12/kontaktdaten' \
 --header 'Content-Type: application/json' \
 --header 'X-TraceId: {{meineTraceId}}' \
 --header 'Authorization: Bearer {{access_token}}'
@@ -96,14 +96,9 @@ Example response Person:
         "plz": "10557",
         "ort": "Berlin"
     },
-    "qualifikation": {
-      "paragraph34d": {
-        "registrierungsnummer": "D-W-133-8B1Z-28"
-      }, 
-      "paragraph34i": {
-        "registrierungsnummer": "D-W-7943497238942",
-        "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
-      } 
+    "Paragraph34c": {
+        "registrierungsNummer": "D-W-7943497238942",
+        "aufsichtsBehörde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
     }
 }
 ```
@@ -125,15 +120,10 @@ Example response Organisation:
         "plz": "10557",
         "ort": "Berlin"
     },
-    "qualifikation": {
-    "paragraph34d": {
-      "registrierungsnummer": "D-W-133-8B1Z-28"
-    },
-    "paragraph34i": {
-      "registrierungsnummer": "D-W-7943497238942",
-      "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
+    "Paragraph34c": {
+        "registrierungsNummer": "D-W-7943497238942",
+        "aufsichtsBehörde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
     }
-  }
 }
 ```
 
@@ -145,7 +135,7 @@ Requirements:
 
 Example request: 
 ``` curl
-curl --location --request GET 'https://api.europace.de/v3/partner/ABC12/' \
+curl --location --request GET 'https://api.europace.de/v2/partner/ABC12/' \
 --header 'Content-Type: application/json' \
 --header 'X-TraceId: {{meineTraceId}}' \
 --header 'Authorization: Bearer {{access_token}}'
@@ -186,15 +176,8 @@ Example response:
       "iban":"DE02120300000000202051",
       "referenzFeld":"Test Ref"
    },
-   "qualifikation": {
-      "paragraph34d": {
-        "registrierungsnummer": "D-W-133-8B1Z-28"
-      },
-      "paragraph34i": {
-        "registrierungsnummer": "D-W-7943497238942",
-        "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
-      }
-   }
+   "aufsichtsbehoerde":"Musterbehoerde",
+   "registrierungsnummer":"987654"
 }
 ```
 
@@ -208,7 +191,7 @@ Requirements:
 
 Example request:
 ```http
-GET /v3/partner/ABC12/partnerkennzeichen HTTP/1.1
+GET /v2/partner/ABC12/partnerkennzeichen HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJ...
@@ -271,7 +254,7 @@ Requirements:
 
 Example request:
 ```http
-GET /v3/partner/ABC12/zugang HTTP/1.1
+GET /v2/partner/ABC12/zugang HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJWRDZZTk...
@@ -314,7 +297,7 @@ Requirements for all use cases and examples:
 
 Example request:
 ``` http
-GET /v3/partner/ABC12/rechte HTTP/1.1
+GET /v2/partner/ABC12/rechte HTTP/1.1
 Host: api.europace.de
 Authorization: Bearer eyJraWQ...
 ```
@@ -352,7 +335,7 @@ The [Zugriffrecht](https://docs.api.europace.de/common/glossary/) entitles partn
 
 Example request:
 ```http
-GET /v3/partner/ABC12/uebernehmbare HTTP/1.1
+GET /v2/partner/ABC12/uebernehmbare HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJ
@@ -378,7 +361,7 @@ Content-Type: application/json;charset=utf-8
 
 Example request:
 ```http
-GET /v3/partner/ABC12/uebernahmeRechtFuer/XYZ15 HTTP/1.1
+GET /v2/partner/ABC12/uebernahmeRechtFuer/XYZ15 HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOi...
@@ -416,7 +399,7 @@ Requirements:
 
 Example request:
 ```http
-GET /v3/partner/ABC12/administrierbare HTTP/1.1
+GET /v2/partner/ABC12/administrierbare HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJWRDZZTk...
@@ -441,7 +424,7 @@ Content-Type: application/json;charset=utf-8
 ## Create partner
 
 Creating a new partner is always done below an existing partner:
-`https://api.europace.de/v3/partner/{PartnerId}/untergeordnete`
+`https://api.europace.de/v2/partner/{PartnerId}/untergeordnete`
 
 Requirements:
 * OAuth token has scope `partner:plakette:anlegen`.
@@ -451,7 +434,7 @@ Requirements:
 
 Example request:
 ``` json 
-POST /v3/partner/ABC12/untergeordnete HTTP/1.1
+POST /v2/partner/ABC12/untergeordnete HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 X-Trace-Id: ff-request-2020-08-28-07-55
@@ -486,16 +469,8 @@ Content-Type: application/json
       "iban":"DE02120300000000202051",
       "referenzFeld":"Test Ref"
    },
-   "qualifikation": {
-      "paragraph34d": {
-        "registrierungsnummer": "D-W-133-8B1Z-28"
-      }, 
-      "paragraph34i": {
-        "registrierungsnummer": "D-W-7943497238942",
-        "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
-      } 
-  }
-
+   "aufsichtsbehoerde":"Musterbehoerde",
+   "registrierungsnummer":"987654"
 }
 ```
 
@@ -516,7 +491,7 @@ The HTTP header "Location" contains the url of the newly created partner.
 Example response:
 ``` json
 201 CREATED
-Location: https://api.europace2.de/v3/partner/ABC12
+Location: https://api.europace2.de/v2/partner/ABC12
 Content-Type: application/json;charset=utf-8
 
 {
@@ -550,15 +525,8 @@ Content-Type: application/json;charset=utf-8
       "iban":"DE02120300000000202051",
       "referenzFeld":"Test Ref"
    },
-   "qualifikation": {
-      "paragraph34d": {
-        "registrierungsnummer": "D-W-133-8B1Z-28"
-      }, 
-      "paragraph34i": {
-        "registrierungsnummer": "D-W-7943497238942",
-        "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
-      } 
-  }
+   "aufsichtsbehoerde":"Musterbehoerde",
+   "registrierungsnummer":"987654"
 }
 ```
 
@@ -583,6 +551,7 @@ To make changes to a partner, the caller needs Einstellungsrechte.
 
 - anrede
 - anschrift
+- aufsichtsbehoerde
 - bankverbindung
 - email
 - externePartnerId
@@ -595,7 +564,7 @@ To make changes to a partner, the caller needs Einstellungsrechte.
 - name
 - vorname
 - nachname
-- qualifikation
+- registrierungsnummer
 - telefonnummer
 - titelFunktion
 - webseite
@@ -607,7 +576,7 @@ Requirements:
 
 Example request:
 ``` json
-PATCH /v3/partner/ABC12 HTTP/1.1
+PATCH /v2/partner/ABC12 HTTP/1.1
 Host: api.europace.de
 Authorization: Bearer eyJraWQiOiJWRDZZ...
 Accept: application/json
@@ -642,15 +611,8 @@ Content-Type: application/json
       "iban":"DE02120300000000202051",
       "referenzFeld":"Test Ref"
    },
-   "qualifikation": {
-      "paragraph34d": {
-        "registrierungsnummer": "D-W-133-8B1Z-28"
-      }, 
-      "paragraph34i": {
-        "registrierungsnummer": "D-W-7943497238942",
-        "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
-      } 
-  }
+   "aufsichtsbehoerde":"Musterbehoerde",
+   "registrierungsnummer":"987654"
 }
 ```
 
@@ -704,15 +666,8 @@ Content-Type: application/json;charset=utf-8
       "bic":"BYLADEM1001",
       "iban":"DE02120300000000202051"
    },
-   "qualifikation": {
-      "paragraph34d": {
-          "registrierungsnummer": "D-W-133-8B1Z-28"
-      },
-      "paragraph34i": {
-          "registrierungsnummer": "D-W-7943497238942",
-          "aufsichtsbehoerde": "IHK Berlin, Fasanenstr. 85, 10623 Berlin"
-      }
-  }
+   "aufsichtsbehoerde":"Musterbehoerde",
+   "registrierungsnummer":"987654"
 }
 ```
 
@@ -739,7 +694,7 @@ Requirement for use case 1:
 
 Example request: 
 ```http
-POST /v3/partner/ABC12/zugang?sendEmail=true HTTP/1.1
+POST /v2/partner/ABC12/zugang?sendEmail=true HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJWRDZZTk...
@@ -774,7 +729,7 @@ Requirement for use case 2:
 
 Example request: 
 ```http
-POST /v3/partner/ABC12/zugang?sendEmail=false HTTP/1.1
+POST /v2/partner/ABC12/zugang?sendEmail=false HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJWRDZZTk...
@@ -807,7 +762,7 @@ Requirements for use case 3:
 
 Example request: 
 ```http
-POST /v3/partner/ABC12/zugang HTTP/1.1
+POST /v2/partner/ABC12/zugang HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJWRDZZTk...
@@ -838,7 +793,7 @@ Restriction:
 
 Example request: 
 ```http
-PATCH /v3/partner/ABC12/zugang HTTP/1.1
+PATCH /v2/partner/ABC12/zugang HTTP/1.1
 Host: api.europace.de
 Accept: application/json
 Authorization: Bearer eyJraWQiOiJWRDZZTk...
@@ -871,7 +826,7 @@ Requirements:
 
 Example request:
 ``` http
-POST /v3/partner/ABC12/rechte HTTP/1.1
+POST /v2/partner/ABC12/rechte HTTP/1.1
 Host: api.europace.de
 Authorization: Bearer eyJraWQ...
 
@@ -919,7 +874,7 @@ Requirements:
 
 Example request:
 ```http
-POST /v3/partner/ABC12/uebernahmeRechtFuer/XYZ56 HTTP/1.1
+POST /v2/partner/ABC12/uebernahmeRechtFuer/XYZ56 HTTP/1.1
 Host: api.europace.de
 X-Trace-Id: My-COLLECTION-8301
 Authorization: Bearer eyJraWQiOiJFT05...

--- a/partner-openapi_2_0.yaml
+++ b/partner-openapi_2_0.yaml
@@ -4,7 +4,7 @@ tags:
   - name: Rechte
 info:
   title: partner-api
-  version: v3.0
+  version: v2.0
   description: Europaces partner management allows organizations to map their own structure to give each partner or employee access and set rights.
   contact:
     name: Europace AG
@@ -12,7 +12,7 @@ info:
     email: info@europace.de
   termsOfService: 'https://docs.api.europace.de/nutzungsbedingungen/'
 servers:
-  - url: 'https://api.europace.de/v3'
+  - url: 'https://api.europace.de/v2'
     description: Produktion Server
 externalDocs:
   url: 'https://docs.api.europace.de/baufinanzierung/partner/partner-api/'
@@ -71,12 +71,6 @@ paths:
                       kontoinhaber: Immofin GmbH
                       bic: PBNKDEFFXXX
                       iban: DE94370100500040661506
-                    qualifikation:
-                      paragraph34d:
-                        registrierungsnummer: D-W-133-8B1Z-28
-                      paragraph34i:
-                        registrierungsnummer": D-W-7943497238942,
-                        aufsichtsbehoerde": 'IHK Berlin, Fasanenstr. 85, 10623 Berlin'
         '401':
           description: Unauthorized
         '403':
@@ -101,6 +95,7 @@ paths:
         ### Attributes that can be changed via PATCH
         - anrede
         - anschrift
+        - aufsichtsbehoerde
         - bankverbindung
         - email
         - externePartnerId
@@ -113,7 +108,7 @@ paths:
         - name
         - vorname
         - nachname
-        - qualifikation
+        - registrierungsnummer
         - telefonnummer
         - titelFunktion
         - webseite
@@ -160,12 +155,8 @@ paths:
                       kontoinhaber: Max Musterman
                       bic: BYLADEM1001
                       iban: DE02120300000000202051
-                    qualifikation:
-                      paragraph34d:
-                        registrierungsnummer: D-W-133-8B1Z-28
-                      paragraph34i:
-                        registrierungsnummer": D-W-7943497238942,
-                        aufsichtsbehoerde": 'IHK Berlin, Fasanenstr. 85, 10623 Berlin'
+                    aufsichtsbehoerde: Musterbehoerde
+                    registrierungsnummer: '987654'
         '400':
           description: Bad Request - Validation failed
           content:
@@ -216,12 +207,8 @@ paths:
                     bic: BYLADEM1001
                     iban: DE02120300000000202051
                     referenzFeld: Test Ref
-                  qualifikation:
-                    paragraph34d:
-                      registrierungsnummer: D-W-133-8B1Z-28
-                    paragraph34i:
-                      registrierungsnummer": D-W-7943497238942,
-                      aufsichtsbehoerde": 'IHK Berlin, Fasanenstr. 85, 10623 Berlin'
+                  aufsichtsbehoerde: Musterbehoerde
+                  registrierungsnummer: '987654'
         description: |-
           You only need to give the attributes, who have to change.
 
@@ -281,12 +268,9 @@ paths:
                       hausnummer: '69'
                       plz: '10557'
                       ort: Berlin
-                    qualifikation:
-                      paragraph34d:
-                        registrierungsnummer: D-W-133-8B1Z-28
-                      paragraph34i:
-                        registrierungsnummer": D-W-7943497238942,
-                        aufsichtsbehoerde": 'IHK Berlin, Fasanenstr. 85, 10623 Berlin'
+                    Paragraph34c:
+                      registrierungsNummer: D-W-7943497238942
+                      aufsichtsBehörde: 'IHK Berlin, Fasanenstr. 85, 10623 Berlin'
         '401':
           description: Unauthorized - Not signed in
           content:
@@ -445,7 +429,7 @@ paths:
         Creates a new partner as an organization or person, depending on the type.
 
         Creating a new partner is always done below an existing partner:
-        `https://api.europace.de/v3/partner/{PartnerId}/untergeordnete`
+        `https://api.europace.de/v2/partner/{PartnerId}/untergeordnete`
 
         Requirements:
         * OAuth token has scope `partner:plakette:anlegen`.
@@ -507,12 +491,8 @@ paths:
                     bic: BYLADEM1001
                     iban: DE02120300000000202051
                     referenzFeld: Test Ref
-                  qualifikation:
-                    paragraph34d:
-                      registrierungsnummer: D-W-133-8B1Z-28
-                    paragraph34i:
-                      registrierungsnummer": D-W-7943497238942,
-                      aufsichtsbehoerde": 'IHK Berlin, Fasanenstr. 85, 10623 Berlin'
+                  aufsichtsbehoerde: Musterbehoerde
+                  registrierungsnummer: '987654'
         description: |-
           The following rules apply to server-side evaluation:
 
@@ -570,12 +550,8 @@ paths:
                       bic: BYLADEM1001
                       iban: DE02120300000000202051
                       referenzFeld: Test Ref
-                    qualifikation:
-                      paragraph34d:
-                        registrierungsnummer: D-W-133-8B1Z-28
-                      paragraph34i:
-                        registrierungsnummer": D-W-7943497238942,
-                        aufsichtsbehoerde": 'IHK Berlin, Fasanenstr. 85, 10623 Berlin'
+                    aufsichtsbehoerde: Musterbehoerde
+                    registrierungsnummer: '987654'
           headers:
             Location:
               schema:
@@ -1156,8 +1132,8 @@ components:
           type: string
         anschrift:
           $ref: '#/components/schemas/Anschrift'
-        qualifikation:
-          $ref: '#/components/schemas/Qualifikation'
+        Paragraph34c:
+          $ref: '#/components/schemas/Paragraph34c'
     Plakette:
       type: object
       description: tree-element of organisational structure
@@ -1241,8 +1217,12 @@ components:
               $ref: '#/components/schemas/Anschrift'
             bankverbindung:
               $ref: '#/components/schemas/Bankverbindung'
-            qualifikation:
-              $ref: '#/components/schemas/Qualifikation'
+            aufsichtsbehoerde:
+              type: string
+              description: supervisor authority
+            registrierungsnummer:
+              type: string
+              description: supervisor auth register number
     Rechte:
       title: Rechte
       type: object
@@ -1458,38 +1438,19 @@ components:
               type: string
             partnerId:
               type: string
-    Paragraph34d:
-      title: Paragraph34d
-      type: object
-      description: Nachweisinformationen für die Zulassung zur Versicherungsvermittlung.
-      properties:
-        registrierungsnummer:
-          type: string
-          example: D-W-153-ULVY-65
-          description: registration number of supervisor authoritity
-    Paragraph34i:
-      title: Paragraph34i
+    Paragraph34c:
+      title: Paragraph34c
       type: object
       description: Nachweisinformationen für die Zulassung zur Baufinanzierungsberatung.
       properties:
-        registrierungsnummer:
+        registrierungsNummer:
           type: string
           example: D-W-153-ULVY-65
           description: registration number of supervisor authoritity
-        aufsichtsbehoerde:
+        aufsichtsBehörde:
           type: string
           example: 'IHK Berlin, Fasanenstraße 85, 10623 Berlin'
           description: supervisor authority
-    Qualifikation:
-      title: Qualifikation
-      type: object
-      description: Nachweisinformationen für die Zulassung zur Baufinanzierungsberatung.
-      properties:
-        paragraph34d:
-          $ref: '#/components/schemas/Paragraph34d'
-        paragraph34i:
-          $ref: '#/components/schemas/Paragraph34i'
-
     Typ:
       type: string
       enum:


### PR DESCRIPTION
Introduction of consistent qualification data in contact data and partner API's. Partner API now also includes qualification data according to Paragraph 34d.
The structure of the qualification data is now consistent with the representation in Europace 2.
![Screenshot 2023-03-21 at 14 55 51](https://user-images.githubusercontent.com/16666709/226832035-41346779-dcf1-4289-a9b6-4d499609590f.png)

Since it is a breaking change, the version number will be bumped to the next major version v3.0.

Version v2.0 is supported in parallel for a transition period.

Changes v2.0 >> v3.0
GET `/partner/{id}/kontaktdaten`
The node `Paragraph34c` in the response was misnamed and already contained the information about Paragraph 34i. Furthermore, it contained invalid characters in the field names. It was replaced in version 3.0 by the node `qualifikation.paragraph34i`.
- `Paragraph34c.registrierungsNummer` >> `qualifikation.paragraph34i.registrierungsnummer`
- `Paragraph34c.aufsichtsBehörde` >> `qualifikation.paragraph34i.aufsichtsbehoerde`
- new response field `qualifikation.paragraph34d.registrierungsnummer`

GET `/partner/{id}`
`aufsichtsbehoerde` and `registrierungsnummer` in the response was replaced by the node `qualifikation.paragraph34i`.
- `registrierungsnummer` >> `qualifikation.paragraph34i.registrierungsnummer`
- `aufsichtsbehoerde` >> `qualifikation.paragraph34i.aufsichtsbehoerde`
- new response field `qualifikation.paragraph34d.registrierungsnummer`

POST `/partner/{id}/untergeordnete`
`aufsichtsbehoerde` and `registrierungsnummer` in the request and response was replaced by the node `qualifikation.paragraph34i`.
- `registrierungsnummer` >> `qualifikation.paragraph34i.registrierungsnummer`
- `aufsichtsbehoerde` >> `qualifikation.paragraph34i.aufsichtsbehoerde`
- new request/response field `qualifikation.paragraph34d.registrierungsnummer`

PATCH `/partner/{id}/untergeordnete`
`aufsichtsbehoerde` and `registrierungsnummer` in the request and response was replaced by the node `qualifikation.paragraph34i`.
- `registrierungsnummer` >> `qualifikation.paragraph34i.registrierungsnummer`
- `aufsichtsbehoerde` >> `qualifikation.paragraph34i.aufsichtsbehoerde`
- new request/response field `qualifikation.paragraph34d.registrierungsnummer`

https://europace.atlassian.net/browse/KITT-2413