### PR TITLE
remove trailing slash in Partner-API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Requirements:
 
 Example request: 
 ``` curl
-curl --location --request GET 'https://api.europace.de/v2/partner/ABC12/' \
+curl --location --request GET 'https://api.europace.de/v2/partner/ABC12' \
 --header 'Content-Type: application/json' \
 --header 'X-TraceId: {{meineTraceId}}' \
 --header 'Authorization: Bearer {{access_token}}'


### PR DESCRIPTION
See https://europace.slack.com/archives/C02BD6DKJF9/p1715177427097429